### PR TITLE
Fix RCE on gitlab-cli

### DIFF
--- a/index.js
+++ b/index.js
@@ -14,6 +14,7 @@ var Promise = require('promise');
 var URL = require('url');
 var options = require('./options')
 var packageJson = require('./package.json')
+const shellescape = require('shell-escape');
 
 var regexParseProjectName = /(.+:\/\/.+?\/|.+:)(.+\/[^\.]+)+(\.git)?/;
 
@@ -56,7 +57,7 @@ function getMergeRequestTitle(title) {
 
       exec('git rev-parse --show-toplevel', function (error, repoDir/*, stderr*/) {
         var filePath = repoDir.trim() + '/.git/PULL_REQUEST_TITLE';
-        exec('git log -1 --pretty=%B > ' + filePath, function (/*error, remote, stderr*/) {
+        exec('git log -1 --pretty=%B > ' + shellescape([filePath]), function (/*error, remote, stderr*/) {
           exec('git config core.editor', function (error, gitEditor/*, stderr*/) {
             editor(filePath, { editor: gitEditor.trim() || null }, function (/*code, sig*/) {
               fs.readFile(filePath, 'utf8', function (err, data) {
@@ -171,8 +172,8 @@ function getRemoteForBranch(branchName) {
         resolve(branchRemoteInfo.remote);
       } else {
         //Remote info is not supplied. Get it from remote set
-        logger.log('Executing git config branch.' + branchName.trim() + '.remote');
-        exec('git config branch.' + branchName.trim() + '.remote', { cwd: projectDir }, function (error, remote/*, stderr*/) {
+        logger.log('Executing git config branch.' + shellescape([branchName.trim()]) + '.remote');
+        exec('git config branch.' + shellescape([branchName.trim()]) + '.remote', { cwd: projectDir }, function (error, remote/*, stderr*/) {
           if (error) {
             console.error(colors.red('Error occured while getting remote of the branch: ', branchName , '\n') );
             console.log('\n\nSet the remote tracking by `git branch --set-upstream-to=origin/'+ branchName + '`. Assuming origin is your remote.');
@@ -194,7 +195,7 @@ function getURLOfRemote(remote) {
   logger.log('\nGetting URL of remote : ' + remote);
   var promise = new Promise(function (resolve/*, reject*/) {
     logger.log('Executing ', 'git config remote.' + remote.trim() + '.url');
-    exec('git config remote.' + remote.trim() + '.url', { cwd: projectDir }, function (error, remoteURL/*, stderr*/) {
+    exec('git config remote.' + shellescape([remote.trim()]) + '.url', { cwd: projectDir }, function (error, remoteURL/*, stderr*/) {
       if (error) {
         console.error(colors.red('Error occured :\n') , colors.red(error));
 

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "gitlab": "^3.0.0",
     "open": "7.2.0",
     "promise": "^7.1.1",
-    "readline-sync": "^1.4.7"
+    "readline-sync": "^1.4.7",
+    "shell-escape": "^0.2.0"
   }
 }


### PR DESCRIPTION
### 📊 Metadata *

#### Bounty URL: https://www.huntr.dev/bounties/1-npm-gitlab-cli/

### ⚙️ Description *

gitlab-cli was vulnerable against arbitrary command injection cause some user supplied inputs were taken and composed into string to be executed without prior validation.
After update Arbitary Code Execution is avoided

### 💻 Technical Description *

Commands that relay on piping functions are excuted so shell-escape was used to clean imput before execution

### 🐛 Proof of Concept (PoC) *

1. Check there aren't files called HACKED
2. Execute the following commands in terminal:
```
npm i git-lab-cli  # Install affected module
lab compare -b 't; touch HACKED; #' #  Run the PoC
```
3. Recheck the files: now HACKED has been created

![Captura de pantalla de 2020-09-09 13-05-53](https://user-images.githubusercontent.com/7505980/92585208-53ec3e00-f29d-11ea-86dc-b14cf77fe7fe.png)

### 🔥 Proof of Fix (PoF) *

After fix no file is created
![Captura de pantalla de 2020-09-09 13-05-30](https://user-images.githubusercontent.com/7505980/92585379-8ac25400-f29d-11ea-8241-00909ac2d447.png)

### 👍 User Acceptance Testing (UAT)

Commands can be executed normally